### PR TITLE
Fix hrefs for github, twitter and vk links in Links component.

### DIFF
--- a/src/components/Links/index.jsx
+++ b/src/components/Links/index.jsx
@@ -19,17 +19,17 @@ class Links extends React.Component {
       <div className="links">
         <ul className="links__list">
           <li className="links__list-item">
-            <a href={links.twitter}>
+            <a href={ `https://www.twitter.com/${links.twitter}` } target="_blank" >
               <i className="icon-twitter" />
             </a>
           </li>
           <li className="links__list-item">
-            <a href={links.github}>
+            <a href={ `https://www.github.com/${links.github}` } target="_blank" >
               <i className="icon-github" />
             </a>
           </li>
           <li className="links__list-item">
-            <a href={links.vk}>
+            <a href={ `https://www.vk.com/${links.vk}`} target="_blank" >
               <i className="icon-vkontakte" />
             </a>
           </li>


### PR DESCRIPTION
Noticed adding my author info inside the gatsby-config.js did not properly update in the Links component. 

The username would be appended to the root URL.

Updated the hrefs so all you have to do is add your account names to get the proper links.