### PR TITLE
Fixes a crash when a post has no tag

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -123,7 +123,7 @@ exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
       value: slug
     });
 
-    if (typeof node.frontmatter.tags !== 'undefined') {
+    if (node.frontmatter.tags) {
       const tagSlugs = node.frontmatter.tags.map(
         tag => `/tags/${_.kebabCase(tag)}/`
       );

--- a/src/components/PostTemplateDetails/index.jsx
+++ b/src/components/PostTemplateDetails/index.jsx
@@ -19,7 +19,7 @@ class PostTemplateDetails extends React.Component {
     const tagsBlock = (
       <div className="post-single__tags">
         <ul className="post-single__tags-list">
-          {tags.map((tag, i) =>
+          {tags && tags.map((tag, i) =>
             <li className="post-single__tags-list-item" key={tag}>
               <Link to={tag} className="post-single__tags-list-item-link">
                 {post.frontmatter.tags[i]}


### PR DESCRIPTION
This commit avoids undefined.map() or null.map() is calling.

When there is no tag in a post, there are two cases in frontmatter.

1)
title: title
categories: Technical
...

2)
title: title
tags:
categories: Technical
...

Let's look at `post.node.frontmatter.tags` in both situations.
`FILE1 = /gatsby-node.js`
`FILE2 = /src/components/PostTemplateDetails/index.jsx`

In the first case, it is `undefined` in `FILE1`.
Cheking `undefined` is already implemented at FILE1#126, so undefined.map()
is not called.
But it is `null` in `FILE2#22`
and a crash will be occurred because it tries to run `null.map()`.

In the second case, it is `null` in `FILE1` and `FILE2`.
In this case, there will be two crashes in both files because both codes
try to run `null.map()`.

This commit avoids these crashes.