### PR TITLE
Decouple the node side code and the browser side code

### DIFF
--- a/src/components/Disqus/Disqus.jsx
+++ b/src/components/Disqus/Disqus.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import ReactDisqusComments from 'react-disqus-comments';
-import config from '../../../gatsby-config';
 
 class Disqus extends Component {
   constructor(props) {
@@ -20,15 +19,15 @@ class Disqus extends Component {
     this.setState({ toasts });
   }
   render() {
-    const { postNode } = this.props;
-    if (!config.siteMetadata.disqusShortname) {
+    const { postNode, siteMetadata } = this.props;
+    if (!siteMetadata.disqusShortname) {
       return null;
     }
     const post = postNode.frontmatter;
-    const url = config.siteMetadata.url + postNode.fields.slug;
+    const url = siteMetadata.url + postNode.fields.slug;
     return (
       <ReactDisqusComments
-        shortname={config.siteMetadata.disqusShortname}
+        shortname={siteMetadata.disqusShortname}
         identifier={post.title}
         title={post.title}
         url={url}

--- a/src/components/PostTemplateDetails/index.jsx
+++ b/src/components/PostTemplateDetails/index.jsx
@@ -32,7 +32,7 @@ class PostTemplateDetails extends React.Component {
 
     const commentsBlock = (
       <div>
-        <Disqus postNode={post} />
+        <Disqus postNode={post} siteMetadata={this.props.data.site.siteMetadata} />
       </div>
     );
 

--- a/src/templates/post-template.jsx
+++ b/src/templates/post-template.jsx
@@ -34,6 +34,8 @@ export const pageQuery = graphql`
           name
           twitter
         }
+        disqusShortname
+        url
       }
     }
     markdownRemark(fields: { slug: { eq: $slug } }) {


### PR DESCRIPTION
It is important decoupling between the node side code and the browser side code, because it allows to use the rich features of the node side. For example, I wanted to use '[dotenv](https://github.com/bkeepers/dotenv)' to keep my secret keys, but it have to be not exposed to browser side. If it is exposed, the web console complains that there is no module 'fs'. To accomplish this, the 'gatsby-config.js' file (and maybe gatsby-node.js..?) must be kept in node code.
However, it exposed into browser code because the Disqus module imports it directly.
To decouple this, all of the siteMetadata information is served via GraphQL.
This commit has this change.

I am sorry to say that, I couldn't test this PR is working on your repository code because my development environment fails to build this repository.
Anyway, the changes of this PR is similar to [my blog's commit](https://github.com/ybbarng/livvy.byb.kr/commit/3ba92360911270847a63f9146811218fbf1856e2) and the changes are very straightforward, I think it will work well.
Please test this PR before merge it because of the lack of test.

References:
https://github.com/gatsbyjs/gatsby/issues/2107#issuecomment-343957893
https://www.gatsbyjs.org/tutorial/part-four/#our-first-graphql-query