### PR TITLE
Improve RSS channel defaults

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    url: 'https://lumen.netlify.com/',
+    url: 'https://lumen.netlify.com',
     title: 'Blog by John Doe',
     subtitle: 'Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed arcu.',
     copyright: '© All rights reserved.',
@@ -44,9 +44,9 @@ module.exports = {
           {
             site {
               siteMetadata {
-                url
+                site_url: url
                 title
-                subtitle
+                description: subtitle
               }
             }
           }
@@ -58,8 +58,8 @@ module.exports = {
                 Object.assign({}, edge.node.frontmatter, {
                   description: edge.node.frontmatter.description,
                   date: edge.node.frontmatter.date,
-                  url: site.siteMetadata.url + edge.node.fields.slug,
-                  guid: site.siteMetadata.url + edge.node.fields.slug,
+                  url: site.siteMetadata.site_url + edge.node.fields.slug,
+                  guid: site.siteMetadata.site_url + edge.node.fields.slug,
                   custom_elements: [{ 'content:encoded': edge.node.html }]
                 }))
             ),


### PR DESCRIPTION
Set the channel link and description to match siteMetadata's URL and subtitle.
```xml
<title>Blog by John Doe</title>
<description>Blog by John Doe</description>
<link>http://github.com/dylang/node-rss</link>
```

becomes

```xml
<title>Blog by John Doe</title>
<description>Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed arcu.</description>
<link>https://lumen.netlify.com/</link>
```

also removed trailing slash in URL as it resulted in a double slash in the feed, leading to a 404

```xml
<link>https://lumen.netlify.com//posts/humane-typography-in-the-digital-age/</link>
```