### PR TITLE
Fix prefix-links error upon deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "npm run clean:public",
     "lint": "./node_modules/.bin/eslint --cache --ext .js,.jsx --ignore-pattern public .",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "deploy": "gatsby build --prefix-links && gh-pages -d public"
+    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
   },
   "repository": "git+https://github.com/alxshelepenok/gatsby-starter-lumen.git",
   "keywords": [


### PR DESCRIPTION
Deploy command throws and error because --prefix-links changed to --prefix-paths as of  https://github.com/gatsbyjs/gatsby/issues/1421