### PR TITLE
Add SEO support

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,9 +1,13 @@
 module.exports = {
   siteMetadata: {
     url: 'https://lumen.netlify.com',
+    pathPrefix: '',
     title: 'Blog by John Doe',
+    titleAlt: 'Blog by John regarding Stuff', // for SEO
+    shareImage: '', // Path to an image when sharing a post on a social network
     subtitle: 'Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed arcu.',
     copyright: '© All rights reserved.',
+    facebookAppID: '', // Facebook Application ID for using app insights
     disqusShortname: '',
     menu: [
       {

--- a/src/components/SEO/index.jsx
+++ b/src/components/SEO/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Helmet from "react-helmet";
+import Helmet from 'react-helmet';
 
 class SEO extends React.Component {
   render() {
@@ -21,70 +21,70 @@ class SEO extends React.Component {
       title = config.title;
       description = config.subtitle;
     }
-    const realPrefix = config.pathPrefix === "/" ? "" : config.pathPrefix;
+    const realPrefix = config.pathPrefix === '/' ? '' : config.pathPrefix;
     const image = config.shareImage !== '' ? config.url + realPrefix + config.shareImage : '';
     const blogURL = config.url + config.pathPrefix;
     const schemaOrgJSONLD = [{
-      "@context": "http://schema.org",
-      "@type": "WebSite",
+      '@context': 'http://schema.org',
+      '@type': 'WebSite',
       url: blogURL,
       name: title,
-      alternateName: config.titleAlt ? config.titleAlt : ""
+      alternateName: config.titleAlt ? config.titleAlt : ''
     }];
     if (postSEO) {
       schemaOrgJSONLD.push([{
-          "@context": "http://schema.org",
-          "@type": "BreadcrumbList",
-          itemListElement: [{
-            "@type": "ListItem",
-            position: 1,
-            item: {
-              "@id": postURL,
-              name: title,
-              image
-            }
-          }]
+        '@context': 'http://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [{
+          '@type': 'ListItem',
+          position: 1,
+          item: {
+            '@id': postURL,
+            name: title,
+            image
+          }
+        }]
+      },
+      {
+        '@context': 'http://schema.org',
+        '@type': 'BlogPosting',
+        url: blogURL,
+        name: title,
+        alternateName: config.titleAlt ? config.titleAlt : '',
+        headline: title,
+        image: {
+          '@type': 'ImageObject',
+          url: image
         },
-        {
-          "@context": "http://schema.org",
-          "@type": "BlogPosting",
-          url: blogURL,
-          name: title,
-          alternateName: config.titleAlt ? config.titleAlt : '',
-          headline: title,
-          image: {
-            "@type": "ImageObject",
-            url: image
-          },
-          description
-        }
+        description
+      }
       ]);
     }
     return (
       <Helmet>
         { /* General tags */ }
-        <meta name = "description" content = { description } />
-        { image !== '' ? <meta name = "image" content = { image } /> : null }
+        <meta name="description" content={description} />
+        { image !== '' ? <meta name="image" content={image} /> : null }
 
         { /* Schema.org tags */ }
-        <script type = "application/ld+json">
+        <script type="application/ld+json">
           { JSON.stringify(schemaOrgJSONLD) }
         </script>
 
         { /* OpenGraph tags */ }
-        <meta property = "og:url" content = { postSEO ? postURL : blogURL } />
-        { postSEO ? <meta property = "og:type" content = "article" /> : null }
-        <meta property = "og:title" content = { title } />
-        <meta property = "og:description" content = { description } />
-        { image !== '' ? <meta property = "og:image" content = { image } /> : null }
-        <meta property = "fb:app_id" content = { config.facebookAppID ? config.facebookAppID : '' } />
+        <meta property="og:url" content={postSEO ? postURL : blogURL} />
+        { postSEO ? <meta property="og:type" content="article" /> : null }
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        { image !== '' ? <meta property="og:image" content={image} /> : null }
+        <meta property="fb:app_id" content={config.facebookAppID ? config.facebookAppID : ''} />
 
         { /* Twitter Card tags */ }
-        <meta name = "twitter:card" content = "summary_large_image" / >
-        <meta name = "twitter:creator" content = { config.author.twitter !== '#' ? config.author.twitter : '' } />
-        <meta name = "twitter:title" content = { title } />
-        <meta name = "twitter:description" content = { description } />
-        { image !== '' ? <meta name = "twitter:image" content = { image } /> : null }
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:creator" content={config.author.twitter !== '#' ? config.author.twitter : ''} />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        { image !== '' ? <meta name="twitter:image" content={image} /> : null }
       </Helmet>
     );
   }

--- a/src/components/SEO/index.jsx
+++ b/src/components/SEO/index.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import Helmet from "react-helmet";
+
+class SEO extends React.Component {
+  render() {
+    const {
+      postNode,
+      postPath,
+      config,
+      postSEO
+    } = this.props;
+    let title;
+    let description;
+    let postURL;
+    if (postSEO) {
+      const postMeta = postNode.frontmatter;
+      title = postMeta.title;
+      description = postMeta.description ? postMeta.description : postNode.excerpt;
+      postURL = config.url + config.pathPrefix + postPath;
+    } else {
+      title = config.title;
+      description = config.subtitle;
+    }
+    const realPrefix = config.pathPrefix === "/" ? "" : config.pathPrefix;
+    const image = config.shareImage !== '' ? config.url + realPrefix + config.shareImage : '';
+    const blogURL = config.url + config.pathPrefix;
+    const schemaOrgJSONLD = [{
+      "@context": "http://schema.org",
+      "@type": "WebSite",
+      url: blogURL,
+      name: title,
+      alternateName: config.titleAlt ? config.titleAlt : ""
+    }];
+    if (postSEO) {
+      schemaOrgJSONLD.push([{
+          "@context": "http://schema.org",
+          "@type": "BreadcrumbList",
+          itemListElement: [{
+            "@type": "ListItem",
+            position: 1,
+            item: {
+              "@id": postURL,
+              name: title,
+              image
+            }
+          }]
+        },
+        {
+          "@context": "http://schema.org",
+          "@type": "BlogPosting",
+          url: blogURL,
+          name: title,
+          alternateName: config.titleAlt ? config.titleAlt : '',
+          headline: title,
+          image: {
+            "@type": "ImageObject",
+            url: image
+          },
+          description
+        }
+      ]);
+    }
+    return (
+      <Helmet>
+        { /* General tags */ }
+        <meta name = "description" content = { description } />
+        { image !== '' ? <meta name = "image" content = { image } /> : null }
+
+        { /* Schema.org tags */ }
+        <script type = "application/ld+json">
+          { JSON.stringify(schemaOrgJSONLD) }
+        </script>
+
+        { /* OpenGraph tags */ }
+        <meta property = "og:url" content = { postSEO ? postURL : blogURL } />
+        { postSEO ? <meta property = "og:type" content = "article" /> : null }
+        <meta property = "og:title" content = { title } />
+        <meta property = "og:description" content = { description } />
+        { image !== '' ? <meta property = "og:image" content = { image } /> : null }
+        <meta property = "fb:app_id" content = { config.facebookAppID ? config.facebookAppID : '' } />
+
+        { /* Twitter Card tags */ }
+        <meta name = "twitter:card" content = "summary_large_image" / >
+        <meta name = "twitter:creator" content = { config.author.twitter !== '#' ? config.author.twitter : '' } />
+        <meta name = "twitter:title" content = { title } />
+        <meta name = "twitter:description" content = { description } />
+        { image !== '' ? <meta name = "twitter:image" content = { image } /> : null }
+      </Helmet>
+    );
+  }
+}
+export default SEO;

--- a/src/templates/category-template.jsx
+++ b/src/templates/category-template.jsx
@@ -5,12 +5,15 @@ import CategoryTemplateDetails from '../components/CategoryTemplateDetails';
 
 class CategoryTemplate extends React.Component {
   render() {
-    const { title } = this.props.data.site.siteMetadata;
+    const { title, subtitle } = this.props.data.site.siteMetadata;
     const { category } = this.props.pathContext;
 
     return (
       <div>
-        <Helmet title={`${category} - ${title}`} />
+        <Helmet>
+          <title>{`${category} - ${title}`}</title>
+          <meta name="description" content={subtitle} />
+        </Helmet>
         <Sidebar {...this.props} />
         <CategoryTemplateDetails {...this.props} />
       </div>

--- a/src/templates/page-template.jsx
+++ b/src/templates/page-template.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Helmet from 'react-helmet';
+import SEO from '../components/SEO';
 import PageTemplateDetails from '../components/PageTemplateDetails';
 
 class PageTemplate extends React.Component {
   render() {
     const { title, subtitle } = this.props.data.site.siteMetadata;
+    const { slug } = this.props.pathContext;
     const page = this.props.data.markdownRemark;
     const { title: pageTitle, description: pageDescription } = page.frontmatter;
     const description = pageDescription !== null ? pageDescription : subtitle;
@@ -13,8 +15,8 @@ class PageTemplate extends React.Component {
       <div>
         <Helmet>
           <title>{`${pageTitle} - ${title}`}</title>
-          <meta name="description" content={description} />
         </Helmet>
+        <SEO postPath={slug} postNode={page} config={this.props.data.site.siteMetadata} />
         <PageTemplateDetails {...this.props} />
       </div>
     );
@@ -27,9 +29,14 @@ export const pageQuery = graphql`
   query PageBySlug($slug: String!) {
     site {
       siteMetadata {
+        url
+        pathPrefix
         title
+        titleAlt
+        shareImage
         subtitle
         copyright
+        facebookAppID
         menu {
           label
           path

--- a/src/templates/post-template.jsx
+++ b/src/templates/post-template.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Helmet from 'react-helmet';
+import SEO from '../components/SEO';
 import PostTemplateDetails from '../components/PostTemplateDetails';
 
 class PostTemplate extends React.Component {
   render() {
     const { title, subtitle } = this.props.data.site.siteMetadata;
+    const { slug } = this.props.pathContext;
     const post = this.props.data.markdownRemark;
     const { title: postTitle, description: postDescription } = post.frontmatter;
     const description = postDescription !== null ? postDescription : subtitle;
@@ -13,8 +15,8 @@ class PostTemplate extends React.Component {
       <div>
         <Helmet>
           <title>{`${postTitle} - ${title}`}</title>
-          <meta name="description" content={description} />
         </Helmet>
+        <SEO postPath={slug} postNode={post} config={this.props.data.site.siteMetadata} postSEO />
         <PostTemplateDetails {...this.props} />
       </div>
     );
@@ -27,9 +29,14 @@ export const pageQuery = graphql`
   query PostBySlug($slug: String!) {
     site {
       siteMetadata {
+        url
+        pathPrefix
         title
+        titleAlt
+        shareImage
         subtitle
         copyright
+        facebookAppID
         author {
           name
           twitter

--- a/src/templates/tag-template.jsx
+++ b/src/templates/tag-template.jsx
@@ -5,12 +5,15 @@ import TagTemplateDetails from '../components/TagTemplateDetails';
 
 class TagTemplate extends React.Component {
   render() {
-    const { title } = this.props.data.site.siteMetadata;
+    const { title, subtitle } = this.props.data.site.siteMetadata;
     const { tag } = this.props.pathContext;
 
     return (
       <div>
-        <Helmet title={`All Posts tagged as "${tag}" - ${title}`} />
+        <Helmet>
+          <title>{`All Posts tagged as "${tag}" - ${title}`}</title>
+          <meta name="description" content={subtitle} />
+        </Helmet>
         <Sidebar {...this.props} />
         <TagTemplateDetails {...this.props} />
       </div>


### PR DESCRIPTION
Added SEO support, shameless "borrowed" from https://github.com/cherihung/gatsby-starter-foundation.

Supports pages, posts, categories, tags, and index. Added support for sharing with a site-wide image. Out-of-the-box, no image is used when sharing to a social network (since posts do not have a cover).

resolves #52 

