### PR TITLE
We want `yarn.lock` in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ npm-debug.log
 .gatsby-context.js
 .idea
 gatsby-starter-lumen.iml
-yarn.lock


### PR DESCRIPTION
Saw that this was removed in ce4665435e12320bb9ec3235f1e23440d27db14f.

It should be a part of git according to the yarn blog here:
https://yarnpkg.com/blog/2016/11/24/lockfiles-for-all/