### PR TITLE
Only create tag / category pages once each

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,161 +1,132 @@
-const _ = require('lodash');
-const Promise = require('bluebird');
-const path = require('path');
-const lost = require('lost');
-const pxtorem = require('postcss-pxtorem');
-const slash = require('slash');
+const _ = require('lodash')
+const Promise = require('bluebird')
+const path = require('path')
+const lost = require('lost')
+const pxtorem = require('postcss-pxtorem')
+const slash = require('slash')
 
 exports.createPages = ({ graphql, boundActionCreators }) => {
-  const { createPage } = boundActionCreators;
+  const { createPage } = boundActionCreators
 
   return new Promise((resolve, reject) => {
-    const postTemplate = path.resolve('./src/templates/post-template.jsx');
-    const pageTemplate = path.resolve('./src/templates/page-template.jsx');
-    const tagTemplate = path.resolve('./src/templates/tag-template.jsx');
-    const categoryTemplate = path.resolve('./src/templates/category-template.jsx');
+    const postTemplate = path.resolve('./src/templates/post-template.jsx')
+    const pageTemplate = path.resolve('./src/templates/page-template.jsx')
+    const tagTemplate = path.resolve('./src/templates/tag-template.jsx')
+    const categoryTemplate = path.resolve(
+      './src/templates/category-template.jsx'
+    )
 
     graphql(`
-    {
-      allMarkdownRemark(
-        limit: 1000,
-        filter: { frontmatter: { draft: { ne: true } } },
-      ) {
-        edges {
-          node {
-            fields {
-              slug
-            }
-            frontmatter {
-              tags
-              layout
-              category
+      {
+        allMarkdownRemark(
+          limit: 1000
+          filter: { frontmatter: { draft: { ne: true } } }
+        ) {
+          edges {
+            node {
+              fields {
+                slug
+              }
+              frontmatter {
+                tags
+                layout
+                category
+              }
             }
           }
         }
       }
-    }
-  `).then((result) => {
+    `).then(result => {
       if (result.errors) {
-        console.log(result.errors);
-        reject(result.errors);
+        console.log(result.errors)
+        reject(result.errors)
       }
 
-      _.each(result.data.allMarkdownRemark.edges, (edge) => {
+      _.each(result.data.allMarkdownRemark.edges, edge => {
         if (_.get(edge, 'node.frontmatter.layout') === 'page') {
           createPage({
             path: edge.node.fields.slug,
             component: slash(pageTemplate),
-            context: { slug: edge.node.fields.slug }
-          });
+            context: { slug: edge.node.fields.slug },
+          })
         } else if (_.get(edge, 'node.frontmatter.layout') === 'post') {
           createPage({
             path: edge.node.fields.slug,
             component: slash(postTemplate),
-            context: { slug: edge.node.fields.slug }
-          });
+            context: { slug: edge.node.fields.slug },
+          })
 
-          let tags = [];
+          let tags = []
           if (_.get(edge, 'node.frontmatter.tags')) {
-            tags = tags.concat(edge.node.frontmatter.tags);
+            tags = tags.concat(edge.node.frontmatter.tags)
           }
 
-          tags = _.uniq(tags);
-          _.each(tags, (tag) => {
-            const tagPath = `/tags/${_.kebabCase(tag)}/`;
+          tags = _.uniq(tags)
+          _.each(tags, tag => {
+            const tagPath = `/tags/${_.kebabCase(tag)}/`
             createPage({
               path: tagPath,
               component: tagTemplate,
-              context: { tag }
-            });
-          });
+              context: { tag },
+            })
+          })
 
-          let categories = [];
+          let categories = []
           if (_.get(edge, 'node.frontmatter.category')) {
-            categories = categories.concat(edge.node.frontmatter.category);
+            categories = categories.concat(edge.node.frontmatter.category)
           }
 
-          categories = _.uniq(categories);
-          _.each(categories, (category) => {
-            const categoryPath = `/categories/${_.kebabCase(category)}/`;
+          categories = _.uniq(categories)
+          _.each(categories, category => {
+            const categoryPath = `/categories/${_.kebabCase(category)}/`
             createPage({
               path: categoryPath,
               component: categoryTemplate,
-              context: { category }
-            });
-          });
+              context: { category },
+            })
+          })
         }
-      });
+      })
 
-      resolve();
-    });
-  });
-};
+      resolve()
+    })
+  })
+}
 
 exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
-  const { createNodeField } = boundActionCreators;
+  const { createNodeField } = boundActionCreators
 
   if (node.internal.type === 'File') {
-    const parsedFilePath = path.parse(node.absolutePath);
-    const slug = `/${parsedFilePath.dir.split('---')[1]}/`;
-    createNodeField({ node, name: 'slug', value: slug });
+    const parsedFilePath = path.parse(node.absolutePath)
+    const slug = `/${parsedFilePath.dir.split('---')[1]}/`
+    createNodeField({ node, name: 'slug', value: slug })
   } else if (
     node.internal.type === 'MarkdownRemark' &&
     typeof node.slug === 'undefined'
   ) {
-    const fileNode = getNode(node.parent);
-    let slug = fileNode.fields.slug;
+    const fileNode = getNode(node.parent)
+    let slug = fileNode.fields.slug
     if (typeof node.frontmatter.path !== 'undefined') {
-      slug = node.frontmatter.path;
+      slug = node.frontmatter.path
     }
     createNodeField({
       node,
       name: 'slug',
-      value: slug
-    });
+      value: slug,
+    })
 
     if (node.frontmatter.tags) {
-      const tagSlugs = node.frontmatter.tags.map(tag => `/tags/${_.kebabCase(tag)}/`);
-      createNodeField({ node, name: 'tagSlugs', value: tagSlugs });
+      const tagSlugs = node.frontmatter.tags.map(
+        tag => `/tags/${_.kebabCase(tag)}/`
+      )
+      createNodeField({ node, name: 'tagSlugs', value: tagSlugs })
     }
 
     if (typeof node.frontmatter.category !== 'undefined') {
-      const categorySlug = `/categories/${_.kebabCase(node.frontmatter.category)}/`;
-      createNodeField({ node, name: 'categorySlug', value: categorySlug });
+      const categorySlug = `/categories/${_.kebabCase(
+        node.frontmatter.category
+      )}/`
+      createNodeField({ node, name: 'categorySlug', value: categorySlug })
     }
   }
-};
-
-exports.modifyWebpackConfig = ({ config }) => {
-  config.merge({
-    postcss: [
-      lost(),
-      pxtorem({
-        rootValue: 16,
-        unitPrecision: 5,
-        propList: [
-          'font',
-          'font-size',
-          'line-height',
-          'letter-spacing',
-          'margin',
-          'margin-top',
-          'margin-left',
-          'margin-bottom',
-          'margin-right',
-          'padding',
-          'padding-top',
-          'padding-left',
-          'padding-bottom',
-          'padding-right',
-          'border-radius',
-          'width',
-          'max-width'
-        ],
-        selectorBlackList: [],
-        replace: true,
-        mediaQuery: false,
-        minPixelValue: 0
-      })
-    ]
-  });
-};
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -42,6 +42,9 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         reject(result.errors)
       }
 
+      let tags = []
+      let categories = []
+
       _.each(result.data.allMarkdownRemark.edges, edge => {
         if (_.get(edge, 'node.frontmatter.layout') === 'page') {
           createPage({
@@ -56,36 +59,38 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
             context: { slug: edge.node.fields.slug },
           })
 
-          let tags = []
+          // Add the tags from this page to our global list of tags
           if (_.get(edge, 'node.frontmatter.tags')) {
             tags = tags.concat(edge.node.frontmatter.tags)
           }
 
-          tags = _.uniq(tags)
-          _.each(tags, tag => {
-            const tagPath = `/tags/${_.kebabCase(tag)}/`
-            createPage({
-              path: tagPath,
-              component: tagTemplate,
-              context: { tag },
-            })
-          })
-
-          let categories = []
+          // Add the category from this page to our global list of categories
           if (_.get(edge, 'node.frontmatter.category')) {
             categories = categories.concat(edge.node.frontmatter.category)
           }
-
-          categories = _.uniq(categories)
-          _.each(categories, category => {
-            const categoryPath = `/categories/${_.kebabCase(category)}/`
-            createPage({
-              path: categoryPath,
-              component: categoryTemplate,
-              context: { category },
-            })
-          })
         }
+      })
+
+      // Create a page for each tag
+      tags = _.uniq(tags)
+      _.each(tags, tag => {
+        const tagPath = `/tags/${_.kebabCase(tag)}/`
+        createPage({
+          path: tagPath,
+          component: tagTemplate,
+          context: { tag },
+        })
+      })
+
+      // Create a page for each category
+      categories = _.uniq(categories)
+      _.each(categories, category => {
+        const categoryPath = `/categories/${_.kebabCase(category)}/`
+        createPage({
+          path: categoryPath,
+          component: categoryTemplate,
+          context: { category },
+        })
       })
 
       resolve()
@@ -129,4 +134,39 @@ exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
       createNodeField({ node, name: 'categorySlug', value: categorySlug })
     }
   }
+}
+
+exports.modifyWebpackConfig = ({ config }) => {
+  config.merge({
+    postcss: [
+      lost(),
+      pxtorem({
+        rootValue: 16,
+        unitPrecision: 5,
+        propList: [
+          'font',
+          'font-size',
+          'line-height',
+          'letter-spacing',
+          'margin',
+          'margin-top',
+          'margin-left',
+          'margin-bottom',
+          'margin-right',
+          'padding',
+          'padding-top',
+          'padding-left',
+          'padding-bottom',
+          'padding-right',
+          'border-radius',
+          'width',
+          'max-width',
+        ],
+        selectorBlackList: [],
+        replace: true,
+        mediaQuery: false,
+        minPixelValue: 0,
+      }),
+    ],
+  })
 }


### PR DESCRIPTION
The significant changes are in 55e598f83f1ca96e329392bf77e11d1b8044a2da.

The other commit is because my editor automatically applies the prettier settings from `.prettierrc`. See #64 

The current starter creates a tag page every time a tag is seen. The tags should be added to the global list, and then only created at the end, not inside the MarkdownRemark each loop.