### PR TITLE
Removed .gatsby-highlight selectors

### DIFF
--- a/src/components/Post/Content/Content.module.scss
+++ b/src/components/Post/Content/Content.module.scss
@@ -44,32 +44,11 @@
       text-decoration: underline
     }
 
-    & .gatsby-highlight {
-      max-width: $layout-post-width;
-      margin-left: 15px;
-      margin-right: 15px;
-      @include margin-bottom(1)
-    }
-
     & *:not(div) {
       width: 100%;
       max-width: $layout-post-width;
       margin-left: auto;
       margin-right: auto
-    }
-
-  }
-
-}
-
-@include breakpoint-sm {
-  .content {
-    &__body {
-      & .gatsby-highlight {
-        margin-left: auto;
-        margin-right: auto
-      }
-
     }
 
   }


### PR DESCRIPTION
The `.gatsby-highlight` selectors don't do anything because it doesn't have a `:global()` qualifier. The CSS styles aren't applied because the class gets changed from `gatsby-highlight` to something else due to CSS Modules:

<img width="573" alt="screen shot 2019-02-04 at 5 38 57 pm" src="https://user-images.githubusercontent.com/10209814/52242178-d469e200-28a3-11e9-98f7-e12772ea9a0a.png">

If you wrap them in `:global()` qualifiers it works, but the styles seem to not be helpful - they make the prism.js code block off center. Since the selectors weren't doing anything to begin with, I've just removed them in this PR since they're dead code.