### PR TITLE
Add isIndex prop to Sidebar in index-template

### DIFF
--- a/src/templates/index-template.js
+++ b/src/templates/index-template.js
@@ -25,7 +25,7 @@ const IndexTemplate = ({ data, pageContext }) => {
 
   return (
     <Layout title={pageTitle} description={siteSubtitle}>
-      <Sidebar />
+      <Sidebar isIndex />
       <Page>
         <Feed edges={edges} />
         <Pagination


### PR DESCRIPTION
A quick codebase search for `<Sidebar` reveals that the `isIndex` prop is never used in Sidebar! I also tried setting it just to see what it looks like, and it basically changes nothing - the difference between an `h1` and `h2` in `<Author />` makes basically no visual difference. This PR removes the `isIndex` prop because it's unused and shouldn't be used.