### PR TITLE
Fixed url prop bug for <ReactDisqusComments />

### DIFF
--- a/src/components/Post/Comments/Comments.js
+++ b/src/components/Post/Comments/Comments.js
@@ -4,7 +4,7 @@ import ReactDisqusComments from 'react-disqus-comments';
 
 export const PureComments = ({ data, postTitle, postSlug }) => {
   const {
-    siteUrl,
+    url,
     disqusShortname
   } = data.site.siteMetadata;
 
@@ -17,7 +17,7 @@ export const PureComments = ({ data, postTitle, postSlug }) => {
       shortname={disqusShortname}
       identifier={postTitle}
       title={postTitle}
-      url={siteUrl + postSlug}
+      url={url + postSlug}
     />
   );
 };

--- a/src/templates/post-template.js
+++ b/src/templates/post-template.js
@@ -43,6 +43,7 @@ export const query = graphql`
       id
       html
       fields {
+        slug
         tagSlugs
       }
       frontmatter {


### PR DESCRIPTION
The `url` prop being passed into `ReactDisqusComments` is wrong - both `siteUrl` and `postSlug` are undefined:

- `siteUrl` should actually be named `url`, see the graphql in `post-template`
- `postSlug` is not included in the graphql for `post-template` and is thus `undefined`

This prop fixes those two values so now the URL is correct. I tested this on my own site (which is based on this starter project) and it works great!