### PR TITLE
filter social media links if they contain just a #

### DIFF
--- a/src/components/Sidebar/Contacts/Contacts.js
+++ b/src/components/Sidebar/Contacts/Contacts.js
@@ -7,16 +7,18 @@ const Contacts = ({ contacts }) => (
   <div className={styles['contacts']}>
     <ul className={styles['contacts__list']}>
       {Object.keys(contacts).map((name) => (
-        <li className={styles['contacts__list-item']} key={name}>
+        contacts[name] !== '#' ?
+          <li className={styles['contacts__list-item']} key={name}>
           <a
-            className={styles['contacts__list-item-link']}
-            href={getContactHref(name, contacts[name])}
-            rel="noopener noreferrer"
-            target="_blank"
+          className={styles['contacts__list-item-link']}
+          href={getContactHref(name, contacts[name])}
+          rel="noopener noreferrer"
+          target="_blank"
           >
-            <Icon icon={getIcon(name)} />
+          <Icon icon={getIcon(name)} />
           </a>
-        </li>
+          </li>
+          : <></>
       ))}
     </ul>
   </div>


### PR DESCRIPTION
Based on a post on [Reddit r/gatsbyjs](https://www.reddit.com/r/gatsbyjs/comments/an7fh9/help_modifying_the_lumen_starter/), I thought it would be a nice addition.

If you do not edit the social links in config.js, then none of the icons get rendered to the page.