### PR TITLE
Add lang="en" to <html>

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -5,6 +5,7 @@ import styles from './Layout.module.scss';
 const Layout = ({ children, title, description }) => (
   <div className={styles.layout}>
     <Helmet>
+      <html lang="en" />
       <title>{title}</title>
       <meta name="description" content={description} />
     </Helmet>


### PR DESCRIPTION
From Google's Lighthouse:
<img width="519" alt="screen shot 2019-02-09 at 5 50 43 pm" src="https://user-images.githubusercontent.com/10209814/52527232-4e7adc00-2c93-11e9-8887-01398cc24226.png">

This PR adds the `lang` attribute to `<html>`.