### PR TITLE
Fix: Testing Netlify locally using gatsby serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ npm run develop
 To test the CMS locally, you'll need run a production build of the site:
 ```
 $ npm run build
-$ npm run serve
+$ gatsby serve
 ```
 
 ## Folder Structure


### PR DESCRIPTION
There is no `serve` script in the package.json. This is meant to be `gatsby serve`

## Description

Fixes the steps on testing the CMS locally.

## Related Issues

None
