### PR TITLE
add pathPrefix configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Open the `blog` directory in your code editor of choice and edit `src/templates/
 
 After clicking that button, you’ll authenticate with GitHub and choose a repository name. Netlify will then automatically create a repository in your GitHub account with a copy of the files from the template. Next, it will build and deploy the new site on Netlify, bringing you to the site dashboard when the build is complete. Next, you’ll need to set up Netlify’s Identity service to authorize users to log in to the CMS.
 
+## Deploy to Github Pages
+
+To deploy to github pages, simply do the following:
+
+- Ensure that your `package.json` file correctly reflects where this repo lives
+- Change the `pathPrefix` in your `config.js`
+- Run the standard deploy command
+
+```sh
+npm run deploy
+```
+
+
 #### Access Locally
 ```
 $ git clone https://github.com/[GITHUB_USERNAME]/[REPO_NAME].git

--- a/config.js
+++ b/config.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   url: 'https://lumen.netlify.com',
+  pathPrefix: '/',
   title: 'Blog by John Doe',
   subtitle: 'Pellentesque odio nisi, euismod in, pharetra a, ultricies in, diam. Sed arcu.',
   copyright: '© All rights reserved.',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,7 @@ const siteConfig = require('./config.js');
 const postCssPlugins = require('./postcss-config.js');
 
 module.exports = {
+  pathPrefix: siteConfig.pathPrefix,
   siteMetadata: {
     url: siteConfig.url,
     title: siteConfig.title,


### PR DESCRIPTION
## Description

We want to add the ability to customize `pathPrefix` for github pages deploys

## Related Issues

https://github.com/alxshelepenok/gatsby-starter-lumen/issues/281

## Changes

- [x] add `pathPrefix` option to `config.js`
- [x] pass `pathPrefix` to gatsby-config
- [x] update readme with github deploy instructions

## Notes

Despite what I said in https://github.com/alxshelepenok/gatsby-starter-lumen/issues/281, apparently it's super easy to add `pathPrefix` capabilities without having to modify the js code at all