### PR TITLE
Hides the contact icon if empty in config

### DIFF
--- a/src/components/Sidebar/Contacts/Contacts.js
+++ b/src/components/Sidebar/Contacts/Contacts.js
@@ -13,7 +13,8 @@ type Props = {
 const Contacts = ({ contacts }: Props) => (
   <div className={styles['contacts']}>
     <ul className={styles['contacts__list']}>
-      {Object.keys(contacts).map((name) => (
+      {Object.keys(contacts).map((name) =>
+      !contacts[name] ? null : (
         <li className={styles['contacts__list-item']} key={name}>
           <a
             className={styles['contacts__list-item-link']}

--- a/src/components/Sidebar/Contacts/Contacts.js
+++ b/src/components/Sidebar/Contacts/Contacts.js
@@ -13,8 +13,7 @@ type Props = {
 const Contacts = ({ contacts }: Props) => (
   <div className={styles['contacts']}>
     <ul className={styles['contacts__list']}>
-      {Object.keys(contacts).map((name) =>
-      !contacts[name] ? null : (
+      {Object.keys(contacts).map((name) => !contacts[name] ? null : (
         <li className={styles['contacts__list-item']} key={name}>
           <a
             className={styles['contacts__list-item-link']}

--- a/src/components/Sidebar/Contacts/Contacts.js
+++ b/src/components/Sidebar/Contacts/Contacts.js
@@ -13,7 +13,7 @@ type Props = {
 const Contacts = ({ contacts }: Props) => (
   <div className={styles['contacts']}>
     <ul className={styles['contacts__list']}>
-      {Object.keys(contacts).map((name) => !contacts[name] ? null : (
+      {Object.keys(contacts).map((name) => (!contacts[name] ? null : (
         <li className={styles['contacts__list-item']} key={name}>
           <a
             className={styles['contacts__list-item-link']}
@@ -24,7 +24,7 @@ const Contacts = ({ contacts }: Props) => (
             <Icon icon={getIcon(name)} />
           </a>
         </li>
-      ))}
+      )))}
     </ul>
   </div>
 );


### PR DESCRIPTION
## Description

Hi, thank you for this awesome starter!
I made this small change for my own blog and figured it could be useful for others as well, as I’m probably not the only user that don’t need all the available contact options. It’s a simple if condition when the contacts settings is looped. If it’s `‘’`_(empty)_ in the config the `<li>` won’t be returned, thus not showing the icon with a url without the username. 
![lumen](https://user-images.githubusercontent.com/1052748/61657687-d42f9880-acc3-11e9-8444-aed9ead57d58.JPG)

