### PR TITLE
Fixed invalid Telegram contact url

### DIFF
--- a/src/components/Sidebar/Contacts/__snapshots__/Contacts.test.js.snap
+++ b/src/components/Sidebar/Contacts/__snapshots__/Contacts.test.js.snap
@@ -107,7 +107,7 @@ exports[`Contacts renders correctly 1`] = `
     >
       <a
         className="contacts__list-item-link"
-        href="telegram:#"
+        href="https://t.me/#"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -105,7 +105,7 @@ exports[`Sidebar renders correctly 1`] = `
         >
           <a
             className="contacts__list-item-link"
-            href="telegram:#"
+            href="https://t.me/#"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/templates/__snapshots__/categories-list-template.test.js.snap
+++ b/src/templates/__snapshots__/categories-list-template.test.js.snap
@@ -108,7 +108,7 @@ exports[`CategoriesListTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="telegram:#"
+              href="https://t.me/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/category-template.test.js.snap
+++ b/src/templates/__snapshots__/category-template.test.js.snap
@@ -108,7 +108,7 @@ exports[`CategoryTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="telegram:#"
+              href="https://t.me/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/index-template.test.js.snap
+++ b/src/templates/__snapshots__/index-template.test.js.snap
@@ -108,7 +108,7 @@ exports[`IndexTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="telegram:#"
+              href="https://t.me/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/not-found-template.test.js.snap
+++ b/src/templates/__snapshots__/not-found-template.test.js.snap
@@ -108,7 +108,7 @@ exports[`NotFoundTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="telegram:#"
+              href="https://t.me/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/page-template.test.js.snap
+++ b/src/templates/__snapshots__/page-template.test.js.snap
@@ -108,7 +108,7 @@ exports[`PageTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="telegram:#"
+              href="https://t.me/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/tag-template.test.js.snap
+++ b/src/templates/__snapshots__/tag-template.test.js.snap
@@ -108,7 +108,7 @@ exports[`TagTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="telegram:#"
+              href="https://t.me/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/tags-list-template.test.js.snap
+++ b/src/templates/__snapshots__/tags-list-template.test.js.snap
@@ -108,7 +108,7 @@ exports[`TagsListTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="telegram:#"
+              href="https://t.me/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/utils/get-contact-href.js
+++ b/src/utils/get-contact-href.js
@@ -13,7 +13,7 @@ const getContactHref = (name: string, contact: string) => {
       href = `https://vk.com/${contact}`;
       break;
     case 'telegram':
-      href = `telegram:${contact}`;
+      href = `https://t.me/${contact}`;
       break;
     case 'email':
       href = `mailto:${contact}`;

--- a/src/utils/get-contact-href.test.js
+++ b/src/utils/get-contact-href.test.js
@@ -6,6 +6,6 @@ test('getContactHref', () => {
   expect(getContactHref('github', '#')).toBe('https://github.com/#');
   expect(getContactHref('email', '#')).toBe('mailto:#');
   expect(getContactHref('vkontakte', '#')).toBe('https://vk.com/#');
-  expect(getContactHref('telegram', '#')).toBe('telegram:#');
+  expect(getContactHref('telegram', '#')).toBe('https://t.me/#');
   expect(getContactHref('rss', '#')).toBe('#');
 });


### PR DESCRIPTION
## Description
I noticed that the generated Telegram link was not up to date. The correct link should be _t.me/username_.
From the Telegram faq:
![image](https://user-images.githubusercontent.com/1052748/61827851-cca7f500-ae65-11e9-816d-2310d34065b4.png)
Source: https://telegram.org/faq#q-how-does-t-me-work

