### PR TITLE
Prevent the page content from jumping due to scrollbar

### DIFF
--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -7,7 +7,7 @@ html {
 
 body {
   margin: 0;
-  margin-left: calc(100vw - 100%);
+  margin: 0 0 0 calc(100vw - 100%);
   font-family: $typographic-font-family;
   color: $typographic-base-font-color;
   line-height: $typographic-base-line-height;

--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -7,6 +7,7 @@ html {
 
 body {
   margin: 0;
+  margin-left: calc(100vw - 100%);
   font-family: $typographic-font-family;
   color: $typographic-base-font-color;
   line-height: $typographic-base-line-height;

--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -6,7 +6,6 @@ html {
 }
 
 body {
-  margin: 0;
   margin: 0 0 0 calc(100vw - 100%);
   font-family: $typographic-font-family;
   color: $typographic-base-font-color;


### PR DESCRIPTION
Currently, the page content will jump slightly when you navigate between two pages if doing so causes the browser's scrollbar to appear/disappear. This simple fix prevents this from happening.

## Description

Introduced the following CSS to the html tag in the [_generic.scss](https://github.com/alxshelepenok/gatsby-starter-lumen/blob/master/src/assets/scss/base/_generic.scss) file.

```css
  margin-left: calc(100vw - 100%);
```
100vw is the size of the entire screen including the scrollbar. 100% is the entire screen **not** including the scrollbar. As a result, margin-left will be the same size as the size of the scrollbar on the right. If there is no scrollbar, then margin-left is 0.


## Related Issues

Fixes #328 
