### PR TITLE
Add netlify preview path support

### DIFF
--- a/content/posts/2016-01-09---Perfecting-the-Art-of-Perfection.md
+++ b/content/posts/2016-01-09---Perfecting-the-Art-of-Perfection.md
@@ -3,7 +3,7 @@ title: Perfecting the Art of Perfection
 date: "2016-09-01T23:46:37.121Z"
 template: "post"
 draft: false
-slug: "/posts/perfecting-the-art-of-perfection/"
+slug: "perfecting-the-art-of-perfection"
 category: "Design Inspiration"
 tags:
   - "Handwriting"

--- a/content/posts/2016-01-12---The-Origins-of-Social-Stationery-Lettering.md
+++ b/content/posts/2016-01-12---The-Origins-of-Social-Stationery-Lettering.md
@@ -3,7 +3,7 @@ title: The Origins of Social Stationery Lettering
 date: "2016-12-01T22:40:32.169Z"
 template: "post"
 draft: false
-slug: "/posts/the-origins-of-social-stationery-lettering"
+slug: "the-origins-of-social-stationery-lettering"
 category: "Design Culture"
 description: "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante."
 socialImage: "/media/image-3.jpg"

--- a/content/posts/2016-02-02---A-Brief-History-of-Typography.md
+++ b/content/posts/2016-02-02---A-Brief-History-of-Typography.md
@@ -3,7 +3,7 @@ title: "A Brief History of Typography"
 date: "2016-02-02T22:40:32.169Z"
 template: "post"
 draft: false
-slug: "/posts/a-brief-history-of-typography/"
+slug: "a-brief-history-of-typography"
 category: "Design Inspiration"
 tags:
   - "Linotype"

--- a/content/posts/2017-18-08---The-Birth-of-Movable-Type.md
+++ b/content/posts/2017-18-08---The-Birth-of-Movable-Type.md
@@ -3,7 +3,7 @@ title: "Johannes Gutenberg: The Birth of Movable Type"
 date: "2017-08-18T22:12:03.284Z"
 template: "post"
 draft: false
-slug: "/posts/the-birth-of-movable-type/"
+slug: "the-birth-of-movable-type"
 category: "Typography"
 tags:
   - "Open source"

--- a/content/posts/2017-19-08---Humane-Typography-in-the-Digital-Age.md
+++ b/content/posts/2017-19-08---Humane-Typography-in-the-Digital-Age.md
@@ -3,7 +3,7 @@ title: Humane Typography in the Digital Age
 date: "2017-08-19T22:40:32.169Z"
 template: "post"
 draft: false
-slug: "/posts/humane-typography-in-the-digital-age/"
+slug: "humane-typography-in-the-digital-age"
 category: "Typography"
 tags:
   - "Design"

--- a/gatsby/on-create-node.js
+++ b/gatsby/on-create-node.js
@@ -8,10 +8,11 @@ const onCreateNode = ({ node, actions, getNode }) => {
 
   if (node.internal.type === 'MarkdownRemark') {
     if (typeof node.frontmatter.slug !== 'undefined') {
+      const dirname = getNode(node.parent).relativeDirectory;
       createNodeField({
         node,
         name: 'slug',
-        value: node.frontmatter.slug
+        value: `/${dirname}/${node.frontmatter.slug}`
       });
     } else {
       const value = createFilePath({ node, getNode });

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -5,12 +5,17 @@ backend:
 media_folder: "static/media"
 public_folder: "/media"
 
+# Uncomment to leverage Netlify CMS UI authoring flow
+# see: https://www.netlifycms.org/docs/configuration-options/#publish-mode
+# publish_mode: editorial_workflow
+
 collections:
   - name: "posts"
     label: "Posts"
     folder: "content/posts"
     create: true
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    preview_path: "posts/{{fields.slug}}"
     fields:
       - {label: "Template", name: "template", widget: "hidden", default: "post"}
       - {label: "Title", name: "title", widget: "string"}


### PR DESCRIPTION
## Description

This PR modifies the slug format in posts to represent a url friendly version of the title rather than a full url. This was modified both to reduce the redundant specification of `/posts/` in all post markdown file slugs, but also unlocks the ability to configure Netlify CMS `preview_path`, which this PR also adds.

See: https://www.netlifycms.org/docs/configuration-options/#preview_path

## Related Issues

Fixes #500 
