### PR TITLE
Include height in postcss pxtorem config

### DIFF
--- a/postcss-config.js
+++ b/postcss-config.js
@@ -12,6 +12,7 @@ module.exports = [
     propList: [
       'font',
       'font-size',
+      'height',
       'line-height',
       'letter-spacing',
       'margin',


### PR DESCRIPTION
## Description

On any browser, if the user configures their default font-size to be something larger than  `$typographic-base-font-size`, it causes the vertical alignment of the tags / home button to be off-center. This is because `height` and `line-height` wind up resolving to different values respectively.

Thus, this PR includes includes `height` in the `pxtorem()` config.

**Before:** 

![Screenshot 2019-12-18 at 10 40 21 PM](https://user-images.githubusercontent.com/16640310/71095542-c2590f80-21e7-11ea-9aaf-e5c201d6c731.png)

![Screenshot 2019-12-18 at 10 46 24 PM](https://user-images.githubusercontent.com/16640310/71095829-3bf0fd80-21e8-11ea-84d4-81bc01ccce6d.png)

**After:**

![Screenshot 2019-12-18 at 10 41 23 PM](https://user-images.githubusercontent.com/16640310/71095532-bd945b80-21e7-11ea-9284-86075bc603ed.png)

![Screenshot 2019-12-18 at 10 45 46 PM](https://user-images.githubusercontent.com/16640310/71095836-3eebee00-21e8-11ea-8027-12b833210ecc.png)

Hope this helps!
