### PR TITLE
Fixed Twitter contact url

### DIFF
--- a/src/components/Post/Author/__snapshots__/Author.test.js.snap
+++ b/src/components/Post/Author/__snapshots__/Author.test.js.snap
@@ -10,7 +10,7 @@ exports[`Author renders correctly 1`] = `
     Test bio
     <a
       className="author__bio-twitter"
-      href="https://www.twitter.com/#"
+      href="https://twitter.com/#"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/src/components/Post/__snapshots__/Post.test.js.snap
+++ b/src/components/Post/__snapshots__/Post.test.js.snap
@@ -81,7 +81,7 @@ exports[`Post renders correctly 1`] = `
         Test bio
         <a
           className="author__bio-twitter"
-          href="https://www.twitter.com/#"
+          href="https://twitter.com/#"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/src/components/Sidebar/Contacts/__snapshots__/Contacts.test.js.snap
+++ b/src/components/Sidebar/Contacts/__snapshots__/Contacts.test.js.snap
@@ -34,7 +34,7 @@ exports[`Contacts renders correctly 1`] = `
     >
       <a
         className="contacts__list-item-link"
-        href="https://www.twitter.com/#"
+        href="https://twitter.com/#"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -130,7 +130,7 @@ exports[`Sidebar renders correctly 1`] = `
         >
           <a
             className="contacts__list-item-link"
-            href="https://www.twitter.com/#"
+            href="https://twitter.com/#"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/templates/__snapshots__/categories-list-template.test.js.snap
+++ b/src/templates/__snapshots__/categories-list-template.test.js.snap
@@ -133,7 +133,7 @@ exports[`CategoriesListTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="https://www.twitter.com/#"
+              href="https://twitter.com/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/category-template.test.js.snap
+++ b/src/templates/__snapshots__/category-template.test.js.snap
@@ -133,7 +133,7 @@ exports[`CategoryTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="https://www.twitter.com/#"
+              href="https://twitter.com/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/index-template.test.js.snap
+++ b/src/templates/__snapshots__/index-template.test.js.snap
@@ -133,7 +133,7 @@ exports[`IndexTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="https://www.twitter.com/#"
+              href="https://twitter.com/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/not-found-template.test.js.snap
+++ b/src/templates/__snapshots__/not-found-template.test.js.snap
@@ -133,7 +133,7 @@ exports[`NotFoundTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="https://www.twitter.com/#"
+              href="https://twitter.com/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/page-template.test.js.snap
+++ b/src/templates/__snapshots__/page-template.test.js.snap
@@ -133,7 +133,7 @@ exports[`PageTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="https://www.twitter.com/#"
+              href="https://twitter.com/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/post-template.test.js.snap
+++ b/src/templates/__snapshots__/post-template.test.js.snap
@@ -84,7 +84,7 @@ exports[`PostTemplate renders correctly 1`] = `
           Test bio
           <a
             className="author__bio-twitter"
-            href="https://www.twitter.com/#"
+            href="https://twitter.com/#"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/templates/__snapshots__/tag-template.test.js.snap
+++ b/src/templates/__snapshots__/tag-template.test.js.snap
@@ -133,7 +133,7 @@ exports[`TagTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="https://www.twitter.com/#"
+              href="https://twitter.com/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/templates/__snapshots__/tags-list-template.test.js.snap
+++ b/src/templates/__snapshots__/tags-list-template.test.js.snap
@@ -133,7 +133,7 @@ exports[`TagsListTemplate renders correctly 1`] = `
           >
             <a
               className="contacts__list-item-link"
-              href="https://www.twitter.com/#"
+              href="https://twitter.com/#"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/utils/get-contact-href.js
+++ b/src/utils/get-contact-href.js
@@ -4,7 +4,7 @@ const getContactHref = (name: string, contact: string) => {
 
   switch (name) {
     case 'twitter':
-      href = `https://www.twitter.com/${contact}`;
+      href = `https://twitter.com/${contact}`;
       break;
     case 'github':
       href = `https://github.com/${contact}`;

--- a/src/utils/get-contact-href.test.js
+++ b/src/utils/get-contact-href.test.js
@@ -2,7 +2,7 @@
 import getContactHref from './get-contact-href';
 
 test('getContactHref', () => {
-  expect(getContactHref('twitter', '#')).toBe('https://www.twitter.com/#');
+  expect(getContactHref('twitter', '#')).toBe('https://twitter.com/#');
   expect(getContactHref('github', '#')).toBe('https://github.com/#');
   expect(getContactHref('email', '#')).toBe('mailto:#');
   expect(getContactHref('vkontakte', '#')).toBe('https://vk.com/#');


### PR DESCRIPTION
## Description

It seems that the Twitter certificate is no longer valid for the `www` subdomain.

<img width="550" alt="twitter_certificate_error" src="https://user-images.githubusercontent.com/1771610/75310800-9c796800-5833-11ea-89cd-af4c6d26995f.png">
