### PR TITLE
Update _generic.scss

### DIFF
--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -140,7 +140,6 @@ figcaption {
   @include line-height(.75);
   @include margin-top(.25);
   color: $color-base;
-  font-size: $typographic-small-font-size;
   font-style: italic;
   margin-bottom: 0;
   text-align: center;


### PR DESCRIPTION
## Description
The `BlinkMacSystemFont`, when set to `italic` and `14px`, it does not behave as it should with Google Chrome print preview.

I had to choose to remove one of the two css properties.

## Related Issues

#685 
