### PR TITLE
Add one digit day of the month in feed

### DIFF
--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -15,7 +15,7 @@ const Feed = ({ edges }: Props) => (
       <div className={styles['feed__item']} key={edge.node.fields.slug}>
         <div className={styles['feed__item-meta']}>
           <time className={styles['feed__item-meta-time']} dateTime={moment(edge.node.frontmatter.date).format('MMMM D, YYYY')}>
-            {moment(edge.node.frontmatter.date).format('MMMM YYYY')}
+            {moment(edge.node.frontmatter.date).format('MMMM D, YYYY')}
           </time>
           <span className={styles['feed__item-meta-divider']} />
           <span className={styles['feed__item-meta-category']}>

--- a/src/components/Feed/__snapshots__/Feed.test.js.snap
+++ b/src/components/Feed/__snapshots__/Feed.test.js.snap
@@ -14,7 +14,7 @@ exports[`Feed renders correctly 1`] = `
         className="feed__item-meta-time"
         dateTime="September 1, 2016"
       >
-        September 2016
+        September 1, 2016
       </time>
       <span
         className="feed__item-meta-divider"
@@ -62,7 +62,7 @@ exports[`Feed renders correctly 1`] = `
         className="feed__item-meta-time"
         dateTime="September 1, 2016"
       >
-        September 2016
+        September 1, 2016
       </time>
       <span
         className="feed__item-meta-divider"

--- a/src/templates/__snapshots__/category-template.test.js.snap
+++ b/src/templates/__snapshots__/category-template.test.js.snap
@@ -252,7 +252,7 @@ exports[`CategoryTemplate renders correctly 1`] = `
                 className="feed__item-meta-time"
                 dateTime="September 1, 2016"
               >
-                September 2016
+                September 1, 2016
               </time>
               <span
                 className="feed__item-meta-divider"
@@ -300,7 +300,7 @@ exports[`CategoryTemplate renders correctly 1`] = `
                 className="feed__item-meta-time"
                 dateTime="September 1, 2016"
               >
-                September 2016
+                September 1, 2016
               </time>
               <span
                 className="feed__item-meta-divider"

--- a/src/templates/__snapshots__/index-template.test.js.snap
+++ b/src/templates/__snapshots__/index-template.test.js.snap
@@ -247,7 +247,7 @@ exports[`IndexTemplate renders correctly 1`] = `
                 className="feed__item-meta-time"
                 dateTime="September 1, 2016"
               >
-                September 2016
+                September 1, 2016
               </time>
               <span
                 className="feed__item-meta-divider"
@@ -295,7 +295,7 @@ exports[`IndexTemplate renders correctly 1`] = `
                 className="feed__item-meta-time"
                 dateTime="September 1, 2016"
               >
-                September 2016
+                September 1, 2016
               </time>
               <span
                 className="feed__item-meta-divider"

--- a/src/templates/__snapshots__/tag-template.test.js.snap
+++ b/src/templates/__snapshots__/tag-template.test.js.snap
@@ -252,7 +252,7 @@ exports[`TagTemplate renders correctly 1`] = `
                 className="feed__item-meta-time"
                 dateTime="September 1, 2016"
               >
-                September 2016
+                September 1, 2016
               </time>
               <span
                 className="feed__item-meta-divider"
@@ -300,7 +300,7 @@ exports[`TagTemplate renders correctly 1`] = `
                 className="feed__item-meta-time"
                 dateTime="September 1, 2016"
               >
-                September 2016
+                September 1, 2016
               </time>
               <span
                 className="feed__item-meta-divider"


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
- Added one digit day for datetime format in feed component.

  Example 
2017-08-19T22:40:32.169Z
It will be AUGUST 19, 2017 instead of AUGUEST, 2017 :)
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
