### PR TITLE
Add social image widget to Netlify CMS config

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -20,6 +20,7 @@ collections:
       - {label: "Template", name: "template", widget: "hidden", default: "post"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Slug", name: "slug", widget: "string"}
+      - {label: "Social Image", name: "socialImage", widget: "image"}
       - {label: "Draft", name: "draft", widget: "boolean", default: true}
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Description", name: "description", widget: "text"}
@@ -36,5 +37,6 @@ collections:
       - {label: "Template", name: "template", widget: "hidden", default: "page"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Slug", name: "slug", widget: "string"}
+      - {label: "Social Image", name: "socialImage", widget: "image"}
       - {label: "Draft", name: "draft", widget: "boolean", default: true}
       - {label: "Body", name: "body", widget: "markdown"}


### PR DESCRIPTION
The gatsby lumen starter currently supports a `socialImage` field in markdown content that will set the `twitter:image` and `og:image` meta tags in the layout component. This feature was added by [this merge](https://github.com/alxshelepenok/gatsby-starter-lumen/pull/375). This PR adds an "Social Image" widget that allows users to set the socialImage field through the netlifycms admin page.