### PR TITLE
Fix mozjpeg unability to compile from source

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,6 +1,6 @@
 FROM node:alpine as builder
 
-RUN apk update && apk add --no-cache make git python autoconf g++ libc6-compat libjpeg-turbo-dev libpng-dev nasm
+RUN apk update && apk add --no-cache make git python autoconf g++ libc6-compat libjpeg-turbo-dev libpng-dev nasm libtool automake
 
 WORKDIR /usr/src/app
 COPY . .


### PR DESCRIPTION
 Fix this error on docker build :
 ⚠ mozjpeg pre-build test failed
  ℹ compiling from source
  ✖ Error: Command failed: /bin/sh -c autoreconf -fiv

## Description

Docker builds worked fine until I've got this error with mozjpeg. Adding libtool and automake to apt packages fixed the issue.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
