### PR TITLE
Change master to main per update by GitHub

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: master
+  branch: main
 
 media_folder: "static/media"
 public_folder: "/media"


### PR DESCRIPTION
## Description

When new users clone this starter, they will need to use main rather than master for their project. GitHub made this update for all new repos starting October 1st, 2020. This change will make the setup easier when connecting the Netlify CMS, for example.
