### PR TITLE
bugfix/ Edit gatsby plugin offline prevent cache static/media

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -194,27 +194,27 @@ module.exports = {
       options: {
         workboxConfig: {
           runtimeCaching: [{
-              // Use cacheFirst since these don't need to be revalidated (same RegExp
-              // and same reason as above)
-              urlPattern: /(\.js$|\.css$|[^:]static\/)/,
-              handler: `CacheFirst`,
-            },
-            {
-              // page-data.json files, static query results and app-data.json
-              // are not content hashed
-              urlPattern: /^https?:.*\/page-data\/.*\.json/,
-              handler: `StaleWhileRevalidate`,
-            },
-            {
-              // Add runtime caching of various other page resources
-              urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
-              handler: `StaleWhileRevalidate`,
-            },
-            {
-              // Google Fonts CSS (doesn't end in .css so we need to specify it)
-              urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
-              handler: `StaleWhileRevalidate`,
-            },
+            // Use cacheFirst since these don't need to be revalidated (same RegExp
+            // and same reason as above)
+            urlPattern: /(\.js$|\.css$|[^:]static\/)/,
+            handler: 'CacheFirst',
+          },
+          {
+            // page-data.json files, static query results and app-data.json
+            // are not content hashed
+            urlPattern: /^https?:.*\/page-data\/.*\.json/,
+            handler: 'StaleWhileRevalidate',
+          },
+          {
+            // Add runtime caching of various other page resources
+            urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
+            handler: 'StaleWhileRevalidate',
+          },
+          {
+            // Google Fonts CSS (doesn't end in .css so we need to specify it)
+            urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
+            handler: 'StaleWhileRevalidate',
+          },
           ],
         },
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -189,7 +189,36 @@ module.exports = {
         icon: 'static/photo.jpg'
       },
     },
-    'gatsby-plugin-offline',
+    {
+      resolve: 'gatsby-plugin-offline',
+      options: {
+        workboxConfig: {
+          runtimeCaching: [{
+              // Use cacheFirst since these don't need to be revalidated (same RegExp
+              // and same reason as above)
+              urlPattern: /(\.js$|\.css$|[^:]static\/)/,
+              handler: `CacheFirst`,
+            },
+            {
+              // page-data.json files, static query results and app-data.json
+              // are not content hashed
+              urlPattern: /^https?:.*\/page-data\/.*\.json/,
+              handler: `StaleWhileRevalidate`,
+            },
+            {
+              // Add runtime caching of various other page resources
+              urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
+              handler: `StaleWhileRevalidate`,
+            },
+            {
+              // Google Fonts CSS (doesn't end in .css so we need to specify it)
+              urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
+              handler: `StaleWhileRevalidate`,
+            },
+          ],
+        },
+      },
+    },
     'gatsby-plugin-catch-links',
     'gatsby-plugin-react-helmet',
     {


### PR DESCRIPTION
## Description
Because we use gatsby-plugin-offline and it caches every request have `static` in URL request like request to static/media so it show the images that not the same in folder static/media.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
