### PR TITLE
Replace deprecated slash SASS operator to `math.div`

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -2,6 +2,8 @@
  * Variables
  */
 
+@use "sass:math";
+
 // Colors
 $color-base: #222;
 $color-primary: #5D93FF;
@@ -25,7 +27,7 @@ $typographic-base-font-color: $color-base;
 $typographic-link-p-font-color: $color-primary;
 $typographic-link-s-font-color: $color-secondary;
 
-$typographic-leading: round(16 * ($typographic-root-font-size / 100) * $typographic-base-line-height);
+$typographic-leading: round(16 * math.div($typographic-root-font-size, 100) * $typographic-base-line-height);
 
 // Buttons
 $button-height: 35px;


### PR DESCRIPTION
## Description
This PR replace the `/` slash operator to `math.div` because the `/` operator for division get deprecated.
https://sass-lang.com/documentation/breaking-changes/slash-div
Also, deprecation warning messages about slash operator do not appear anymore in console.

## Related Issues
fixes #955 