### PR TITLE
fix slash div warning

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -1,6 +1,7 @@
-/** 
+/**
  * Variables
  */
+@use "sass:math";
 
 // Colors
 $color-base: #222;
@@ -25,7 +26,7 @@ $typographic-base-font-color: $color-base;
 $typographic-link-p-font-color: $color-primary;
 $typographic-link-s-font-color: $color-secondary;
 
-$typographic-leading: round(16 * ($typographic-root-font-size / 100) * $typographic-base-line-height);
+$typographic-leading: round(16 * math.div($typographic-root-font-size, 100) * $typographic-base-line-height);
 
 // Buttons
 $button-height: 35px;


### PR DESCRIPTION
## Description

I found the following warning right after `gatsby develop`.

    ⠋ Building development bundle
    DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

    Recommendation: math.div($typographic-root-font-size, 100)

    More info and automated migrator: https://sass-lang.com/d/slash-div

       ╷
    28 │  $typographic-leading: round(16 * ($typographic-root-font-size / 100) * $typographic-base-line-height);
       │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       ╵
        src/assets/scss/_variables.scss 28:35  @import
        src/assets/scss/init.scss 3:9          root stylesheet

## Related Issues

Not yet, but I believe this PR can fix it.
