### PR TITLE
Fix Dockerfile.production

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,6 +1,6 @@
 FROM node:alpine as builder
 
-RUN apk update && apk add --no-cache make git python autoconf g++ libc6-compat libjpeg-turbo-dev libpng-dev nasm libtool automake
+RUN apk update && apk add --no-cache make git python3 autoconf g++ libc6-compat libjpeg-turbo-dev libpng-dev nasm libtool automake vips-dev
 
 WORKDIR /usr/src/app
 COPY . .


### PR DESCRIPTION
## Description

When I tried to build an image using `Dockerfile.production` in my environment, it failed. This is a PR for the fix.

### Errors
**Python**  
The package name seems to have changed.
```
ERROR: unable to select packages:
  python (no such package):
    required by: world[python]
ERROR: Service 'web' failed to build: The command '/bin/sh -c apk update && apk add --no-cache make git 
python autoconf g++ libc6-compat libjpeg-turbo-dev libpng-dev nasm libtool automake' returned a non-zero code: 1
```

**vips-dev**
```
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
<command-line>: warning: "_GLIBCXX_USE_CXX11_ABI" redefined
<command-line>: note: this is the location of the previous definition
../src/common.cc:24:10: fatal error: vips/vips8: No such file or directory
   24 | #include <vips/vips8>
      |          ^~~~~~~~~~~~
compilation terminated.
make: *** [sharp.target.mk:141: Release/obj.target/sharp/src/common.o] Error 1
``` 

### Enviroment
```
$ uname -a
Linux momoi 5.12.11-arch1-1 #1 SMP PREEMPT Wed, 16 Jun 2021 15:25:28 +0000 x86_64 GNU/Linux
$ docker -v
Docker version 20.10.7, build f0df35096d
```

## Related Issues
Not yet.
 