### PR TITLE
fix: fix link is too long in mobile view

### DIFF
--- a/src/components/Post/Content/Content.module.scss
+++ b/src/components/Post/Content/Content.module.scss
@@ -41,7 +41,8 @@
     }
 
     & a {
-      text-decoration: underline
+      text-decoration: underline;
+      word-break: break-word;
     }
 
     & * {


### PR DESCRIPTION
## Description

- If a link (an anchor tag) is too long, in mobile view, it's overflow in the x-axis, make it horizontally scrollable. I attached images before and after I applied the fix.

Before:
<img width="517" alt="Screenshot 2021-09-06 at 00 21 28" src="https://user-images.githubusercontent.com/8603085/132135933-a2366f78-6bcb-410c-ab71-84898b03a2ff.png">

After:
<img width="501" alt="Screenshot 2021-09-06 at 00 22 05" src="https://user-images.githubusercontent.com/8603085/132135940-e362e11d-c0a3-4b66-8b86-003ba6c4f5ff.png">


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
