### PR TITLE
Fix: clear build warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,29 @@
     "rules": {
       "comma-dangle": 0,
       "import/imports-first": 0,
+      "import/order": [
+        2,
+        {
+          "alphabetize": { "order": "asc" },
+          "groups": [
+            "builtin",
+            "external",
+            "internal",
+            "index",
+            "sibling",
+            "parent",
+            "object"
+          ],
+          "pathGroups": [
+            {
+              "pattern": "react*",
+              "group": "builtin",
+              "position": "before"
+            }
+          ],
+          "pathGroupsExcludedImportTypes": ["react", "builtin"]
+        }
+      ],
       "global-require": 0,
       "class-methods-use-this": 0,
       "arrow-body-style": [

--- a/gatsby/create-pages.js
+++ b/gatsby/create-pages.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const _ = require('lodash');
 const createCategoriesPages = require('./pagination/create-categories-pages.js');
-const createTagsPages = require('./pagination/create-tags-pages.js');
 const createPostsPages = require('./pagination/create-posts-pages.js');
+const createTagsPages = require('./pagination/create-tags-pages.js');
 
 const createPages = async ({ graphql, actions }) => {
   const { createPage } = actions;

--- a/gatsby/on-create-node.js
+++ b/gatsby/on-create-node.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
 const { createFilePath } = require('gatsby-source-filesystem');
+const _ = require('lodash');
 
 const onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions;

--- a/gatsby/pagination/create-categories-pages.js
+++ b/gatsby/pagination/create-categories-pages.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
 const path = require('path');
+const _ = require('lodash');
 const siteConfig = require('../../config.js');
 
 module.exports = async (graphql, actions) => {

--- a/gatsby/pagination/create-tags-pages.js
+++ b/gatsby/pagination/create-tags-pages.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
 const path = require('path');
+const _ = require('lodash');
 const siteConfig = require('../../config.js');
 
 module.exports = async (graphql, actions) => {

--- a/postcss-config.js
+++ b/postcss-config.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const autoprefixer = require('autoprefixer');
 const lost = require('lost');
 const pxtorem = require('postcss-pxtorem');
-const autoprefixer = require('autoprefixer');
 
 module.exports = [
   lost(),

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -1,8 +1,8 @@
 // @flow strict
 import React from 'react';
 import { Link } from 'gatsby';
-import type { Edges } from '../../types';
 import styles from './Feed.module.scss';
+import type { Edges } from '../../types';
 
 type Props = {
   edges: Edges

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,9 +1,9 @@
 // @flow strict
 import React from 'react';
-import Helmet from 'react-helmet';
 import type { Node as ReactNode } from 'react';
-import { useSiteMetadata } from '../../hooks';
+import Helmet from 'react-helmet';
 import styles from './Layout.module.scss';
+import { useSiteMetadata } from '../../hooks';
 
 type Props = {
   children: ReactNode,

--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { useStaticQuery, StaticQuery } from 'gatsby';
-import siteMetadata from '../../../jest/__fixtures__/site-metadata';
 import Layout from './Layout';
+import siteMetadata from '../../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../../types';
 
 describe('Layout', () => {

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import classNames from 'classnames/bind';
 import { Link } from 'gatsby';
-import { PAGINATION } from '../../constants';
 import styles from './Pagination.module.scss';
+import { PAGINATION } from '../../constants';
 
 type Props = {
   prevPagePath: string,

--- a/src/components/Post/Author/Author.js
+++ b/src/components/Post/Author/Author.js
@@ -1,8 +1,8 @@
 // @flow strict
 import React from 'react';
-import { getContactHref } from '../../../utils';
 import styles from './Author.module.scss';
 import { useSiteMetadata } from '../../../hooks';
+import { getContactHref } from '../../../utils';
 
 const Author = () => {
   const { author } = useSiteMetadata();

--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -5,8 +5,8 @@ import Author from './Author';
 import Comments from './Comments';
 import Content from './Content';
 import Meta from './Meta';
-import Tags from './Tags';
 import styles from './Post.module.scss';
+import Tags from './Tags';
 import type { Node } from '../../types';
 
 type Props = {

--- a/src/components/Sidebar/Contacts/Contacts.js
+++ b/src/components/Sidebar/Contacts/Contacts.js
@@ -1,8 +1,8 @@
 // @flow strict
 import React from 'react';
+import styles from './Contacts.module.scss';
 import { getContactHref, getIcon } from '../../../utils';
 import Icon from '../../Icon';
-import styles from './Contacts.module.scss';
 
 type Props = {
   contacts: {

--- a/src/templates/categories-list-template.js
+++ b/src/templates/categories-list-template.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import kebabCase from 'lodash/kebabCase';
-import Sidebar from '../components/Sidebar';
 import Layout from '../components/Layout';
 import Page from '../components/Page';
+import Sidebar from '../components/Sidebar';
 import { useSiteMetadata, useCategoriesList } from '../hooks';
 
 const CategoriesListTemplate = () => {

--- a/src/templates/categories-list-template.test.js
+++ b/src/templates/categories-list-template.test.js
@@ -3,8 +3,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { useStaticQuery, StaticQuery } from 'gatsby';
 import CategoriesListTemplate from './categories-list-template';
-import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import allMarkdownRemark from '../../jest/__fixtures__/all-markdown-remark';
+import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../types';
 
 describe('CategoriesListTemplate', () => {

--- a/src/templates/category-template.js
+++ b/src/templates/category-template.js
@@ -1,11 +1,11 @@
 // @flow strict
 import React from 'react';
 import { graphql } from 'gatsby';
-import Layout from '../components/Layout';
-import Sidebar from '../components/Sidebar';
 import Feed from '../components/Feed';
+import Layout from '../components/Layout';
 import Page from '../components/Page';
 import Pagination from '../components/Pagination';
+import Sidebar from '../components/Sidebar';
 import { useSiteMetadata } from '../hooks';
 import type { PageContext, AllMarkdownRemark } from '../types';
 

--- a/src/templates/category-template.test.js
+++ b/src/templates/category-template.test.js
@@ -3,9 +3,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { useStaticQuery, StaticQuery } from 'gatsby';
 import CategoryTemplate from './category-template';
-import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import allMarkdownRemark from '../../jest/__fixtures__/all-markdown-remark';
 import pageContext from '../../jest/__fixtures__/page-context';
+import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../types';
 
 describe('CategoryTemplate', () => {

--- a/src/templates/index-template.js
+++ b/src/templates/index-template.js
@@ -1,11 +1,11 @@
 // @flow strict
 import React from 'react';
 import { graphql } from 'gatsby';
-import Layout from '../components/Layout';
-import Sidebar from '../components/Sidebar';
 import Feed from '../components/Feed';
+import Layout from '../components/Layout';
 import Page from '../components/Page';
 import Pagination from '../components/Pagination';
+import Sidebar from '../components/Sidebar';
 import { useSiteMetadata } from '../hooks';
 import type { PageContext, AllMarkdownRemark } from '../types';
 

--- a/src/templates/index-template.test.js
+++ b/src/templates/index-template.test.js
@@ -3,9 +3,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { StaticQuery, useStaticQuery } from 'gatsby';
 import IndexTemplate from './index-template';
-import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import allMarkdownRemark from '../../jest/__fixtures__/all-markdown-remark';
 import pageContext from '../../jest/__fixtures__/page-context';
+import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../types';
 
 describe('IndexTemplate', () => {

--- a/src/templates/not-found-template.js
+++ b/src/templates/not-found-template.js
@@ -1,8 +1,8 @@
 // @flow strict
 import React from 'react';
-import Sidebar from '../components/Sidebar';
 import Layout from '../components/Layout';
 import Page from '../components/Page';
+import Sidebar from '../components/Sidebar';
 import { useSiteMetadata } from '../hooks';
 
 const NotFoundTemplate = () => {

--- a/src/templates/page-template.js
+++ b/src/templates/page-template.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import Layout from '../components/Layout';
-import Sidebar from '../components/Sidebar';
 import Page from '../components/Page';
+import Sidebar from '../components/Sidebar';
 import { useSiteMetadata } from '../hooks';
 import type { MarkdownRemark } from '../types';
 

--- a/src/templates/page-template.test.js
+++ b/src/templates/page-template.test.js
@@ -3,8 +3,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { useStaticQuery, StaticQuery } from 'gatsby';
 import PageTemplate from './page-template';
-import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import markdownRemark from '../../jest/__fixtures__/markdown-remark';
+import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../types';
 
 describe('PageTemplate', () => {

--- a/src/templates/post-template.test.js
+++ b/src/templates/post-template.test.js
@@ -3,8 +3,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { useStaticQuery, StaticQuery } from 'gatsby';
 import PostTemplate from './post-template';
-import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import markdownRemark from '../../jest/__fixtures__/markdown-remark';
+import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../types';
 
 describe('PostTemplate', () => {

--- a/src/templates/tag-template.js
+++ b/src/templates/tag-template.js
@@ -1,11 +1,11 @@
 // @flow strict
 import React from 'react';
 import { graphql } from 'gatsby';
-import Layout from '../components/Layout';
-import Sidebar from '../components/Sidebar';
 import Feed from '../components/Feed';
+import Layout from '../components/Layout';
 import Page from '../components/Page';
 import Pagination from '../components/Pagination';
+import Sidebar from '../components/Sidebar';
 import { useSiteMetadata } from '../hooks';
 import type { AllMarkdownRemark, PageContext } from '../types';
 

--- a/src/templates/tag-template.test.js
+++ b/src/templates/tag-template.test.js
@@ -3,9 +3,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { useStaticQuery, StaticQuery } from 'gatsby';
 import TagTemplate from './tag-template';
-import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import allMarkdownRemark from '../../jest/__fixtures__/all-markdown-remark';
 import pageContext from '../../jest/__fixtures__/page-context';
+import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../types';
 
 describe('TagTemplate', () => {

--- a/src/templates/tags-list-template.js
+++ b/src/templates/tags-list-template.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { Link } from 'gatsby';
 import kebabCase from 'lodash/kebabCase';
 import Layout from '../components/Layout';
-import Sidebar from '../components/Sidebar';
 import Page from '../components/Page';
+import Sidebar from '../components/Sidebar';
 import { useSiteMetadata, useTagsList } from '../hooks';
 
 const TagsListTemplate = () => {

--- a/src/templates/tags-list-template.test.js
+++ b/src/templates/tags-list-template.test.js
@@ -3,8 +3,8 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { useStaticQuery, StaticQuery } from 'gatsby';
 import TagsListTemplate from './tags-list-template';
-import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import allMarkdownRemark from '../../jest/__fixtures__/all-markdown-remark';
+import siteMetadata from '../../jest/__fixtures__/site-metadata';
 import type { RenderCallback } from '../types';
 
 describe('TagsListTemplate', () => {


### PR DESCRIPTION
## Description

Hi! I was maintaining a project based on this starter and currently run `yarn build` will print tons of warning which is caused by https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250#issuecomment-415345126. To fix this I applied the eslint rule `import/order`. Thanks for this starter anyway! 

```
warn chunk styles [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Sidebar/Author/Author.module.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Layout/Layout.module.scss
   - couldn't fulfill desired order of chunk group(s) component---src-templates-category-template-js,
component---src-templates-index-template-js, component---src-templates-page-template-js,
component---src-templates-tag-template-js, component---src-templates-tags-list-template-js
   - while fulfilling desired order of chunk group(s)
component---src-templates-categories-list-template-js, component---src-templates-not-found-template-js
warn chunk styles [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Icon/Icon.module.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Layout/Layout.module.scss
   - couldn't fulfill desired order of chunk group(s) component---src-templates-category-template-js,
component---src-templates-index-template-js, component---src-templates-page-template-js,
component---src-templates-tag-template-js, component---src-templates-tags-list-template-js
   - while fulfilling desired order of chunk group(s)
component---src-templates-categories-list-template-js, component---src-templates-not-found-template-js
warn chunk styles [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Sidebar/Contacts/Contacts.module.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Layout/Layout.module.scss
   - couldn't fulfill desired order of chunk group(s) component---src-templates-category-template-js,
component---src-templates-index-template-js, component---src-templates-page-template-js,
component---src-templates-tag-template-js, component---src-templates-tags-list-template-js
   - while fulfilling desired order of chunk group(s)
component---src-templates-categories-list-template-js, component---src-templates-not-found-template-js
warn chunk styles [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Sidebar/Copyright/Copyright.module.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Layout/Layout.module.scss
   - couldn't fulfill desired order of chunk group(s) component---src-templates-category-template-js,
component---src-templates-index-template-js, component---src-templates-page-template-js,
component---src-templates-tag-template-js, component---src-templates-tags-list-template-js
   - while fulfilling desired order of chunk group(s)
component---src-templates-categories-list-template-js, component---src-templates-not-found-template-js
warn chunk styles [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Sidebar/Menu/Menu.module.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Layout/Layout.module.scss
   - couldn't fulfill desired order of chunk group(s) component---src-templates-category-template-js,
component---src-templates-index-template-js, component---src-templates-page-template-js,
component---src-templates-tag-template-js, component---src-templates-tags-list-template-js
   - while fulfilling desired order of chunk group(s)
component---src-templates-categories-list-template-js, component---src-templates-not-found-template-js
warn chunk styles [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Sidebar/Sidebar.module.scss
despite it was not able to fulfill desired ordering with these modules:
 * css ./node_modules/css-loader??ref--13-oneOf-0-1!./node_modules/postcss-loader/src??postcss-4!./node_mo
dules/sass-loader/dist/cjs.js??ref--13-oneOf-0-3!./src/components/Layout/Layout.module.scss
   - couldn't fulfill desired order of chunk group(s) component---src-templates-category-template-js,
component---src-templates-index-template-js, component---src-templates-page-template-js,
component---src-templates-tag-template-js, component---src-templates-tags-list-template-js
   - while fulfilling desired order of chunk group(s)
component---src-templates-categories-list-template-js, component---src-templates-not-found-template-js
```

## Related Issues