### PR TITLE
Fix console warnings

### DIFF
--- a/src/components/Sidebar/Contacts/Contacts.js
+++ b/src/components/Sidebar/Contacts/Contacts.js
@@ -13,13 +13,14 @@ type Props = {
 const Contacts = ({ contacts }: Props) => (
   <div className={styles['contacts']}>
     <ul className={styles['contacts__list']}>
-      {Object.keys(contacts).map((name) => (!contacts[name] ? null : (
+      {Object.keys(contacts).map((name, key) => (!contacts[name] ? null : (
         <li className={styles['contacts__list-item']} key={name}>
           <a
             className={styles['contacts__list-item-link']}
             href={getContactHref(name, contacts[name])}
             rel="noopener noreferrer"
             target="_blank"
+            key={key}
           >
             <Icon name={name} icon={getIcon(name)} />
           </a>


### PR DESCRIPTION
Fixing console warning `Warning: Each child in a list should have a unique "key" prop.`
```
Warning: Each child in a list should have a unique "key" prop
Check the render method of `Contacts`. See https://reactjs.org/link/warning-keys for more information.
    at a
    at Contacts (webpack-internal:///./src/components/Sidebar/Contacts/Contacts.js:20:23)
```

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
